### PR TITLE
Stop GitHub from reporting "74.6% Coq"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Help GitHub correctly report the project language
+*.v linguist-language=Verilog


### PR DESCRIPTION
On the title page of the project, GitHub incorrectly autodetects the language as "74.6% Coq".  Help Linguist by manually telling it all those .v files are Verilog, not Coq.