### PR TITLE
Avoid SystemVerilog reserved words

### DIFF
--- a/rel/src/verilog/work/lq_byp.v
+++ b/rel/src/verilog/work/lq_byp.v
@@ -608,9 +608,9 @@ assign ex4_req_aborted_d  = ex3_req_aborted_q;
 assign ex5_req_aborted_d  = ex4_req_aborted_q;
 
 generate begin : ex5ParGen
-    genvar byte;
-    for (byte=0; byte<=((2**`GPR_WIDTH_ENC)-1)/8; byte=byte+1) begin : ex5ParGen
-        assign ex5_fx_ld_data_par[byte] = ^(ex5_fx_ld_data[(64-(2**`GPR_WIDTH_ENC))+(byte*8):(64-(2**`GPR_WIDTH_ENC))+(byte*8)+7]);
+    genvar b;
+    for (b=0; b<=((2**`GPR_WIDTH_ENC)-1)/8; b=b+1) begin : ex5ParGen
+        assign ex5_fx_ld_data_par[b] = ^(ex5_fx_ld_data[(64-(2**`GPR_WIDTH_ENC))+(b*8):(64-(2**`GPR_WIDTH_ENC))+(b*8)+7]);
     end
   end
 endgenerate
@@ -891,9 +891,9 @@ assign lq_pc_ram_data = lq_pc_ram_data_q;
 // Reload Data Parity Generation
 //----------------------------------------------------------------------------------------------------------------------------------------
 generate begin : relParGen
-  genvar byte;
-  for (byte = 0; byte <= (`STQ_DATA_SIZE- 1)/8; byte=byte+1) begin : relParGen
-    assign rel2_data_par[byte] = ^(lsq_ctl_rel2_data[(128-`STQ_DATA_SIZE) + byte*8:((128-`STQ_DATA_SIZE))+(byte*8)+7]);
+  genvar b;
+  for (b = 0; b <= (`STQ_DATA_SIZE- 1)/8; b=b+1) begin : relParGen
+    assign rel2_data_par[b] = ^(lsq_ctl_rel2_data[(128-`STQ_DATA_SIZE) + b*8:((128-`STQ_DATA_SIZE))+(b*8)+7]);
   end
 end
 endgenerate

--- a/rel/src/verilog/work/xu.v
+++ b/rel/src/verilog/work/xu.v
@@ -841,7 +841,7 @@ module xu(
    generate begin : parGen
       genvar b;
       for (b=0;b<=`GPR_WIDTH/8-1;b=b+1)
-      begin : byte
+      begin : parGen
          assign lq_xu_gpr_ex6_par[b] = ^(lq_xu_gpr_ex6_wd_q[(64 - `GPR_WIDTH) + b * 8:(64 - `GPR_WIDTH) + (b * 8) + 7]);
       end
    end

--- a/rel/src/verilog/work/xu0.v
+++ b/rel/src/verilog/work/xu0.v
@@ -550,7 +550,7 @@ module xu0
    generate begin : bperm
       genvar i;
       for (i=0;i<=7;i=i+1) begin : bprm_bit
-         xu0_bprm bit(
+         xu0_bprm bperm_bit(
             .a(byp_alu_ex2_rs2),
             .s(byp_alu_ex2_rs1[8 * i + 0:8 * i + 7]),
             .y(prm_byp_ex2_rt[56 + i])

--- a/rel/src/verilog/work/xu1_byp.v
+++ b/rel/src/verilog/work/xu1_byp.v
@@ -503,9 +503,9 @@ module xu1_byp(
    //------------------------------------------------------------------------------------------
    // Parity Gen
    //------------------------------------------------------------------------------------------
-   generate begin : parity
+   generate begin : ex3ParGen
       genvar i;
-         for (i=8-`GPR_WIDTH/8;i<=7;i=i+1) begin : byte
+         for (i=8-`GPR_WIDTH/8;i<=7;i=i+1) begin : ex3ParGen
             assign ex3_parity[i] = ^(alu_byp_ex3_rt[8*i:8*i+7]);
          end
       end


### PR DESCRIPTION
Yosys doesn't like bit and byte being used as identifiers.